### PR TITLE
add recipe source reference to table

### DIFF
--- a/db/migrate/20181119170609_add_column_to_recipe.rb
+++ b/db/migrate/20181119170609_add_column_to_recipe.rb
@@ -1,0 +1,5 @@
+class AddColumnToRecipe < ActiveRecord::Migration[5.2]
+  def change
+    add_column :recipes, :source, :string
+  end
+end


### PR DESCRIPTION
IMPORTANT: `rails db:migration` required after pull. To prepare for publication, adding recipe's origin name to recipe table - schema must be changed.