### PR TITLE
change table creation migration for recipe_companents to recipe_ingre…

### DIFF
--- a/db/migrate/20181117074756_create_recipe_ingredients.rb
+++ b/db/migrate/20181117074756_create_recipe_ingredients.rb
@@ -1,6 +1,6 @@
-class CreateRecipeComponents < ActiveRecord::Migration[5.2]
+class CreateRecipeIngredients < ActiveRecord::Migration[5.2]
   def change
-    create_table :recipe_components do |t|
+    create_table :recipe_ingredients do |t|
       t.string :metric_quantity
       t.string :imperial_quantity
       t.references :ingredients, foreign_key: true


### PR DESCRIPTION
Following Andrea's suggestion, this pull request would remove the migration which created the 'recipe_components' table and replace it with a migration that creates a 'recipe_ingredients' join table.