### PR TITLE
change recipe instructions column type

### DIFF
--- a/db/migrate/20181117073558_create_recipes.rb
+++ b/db/migrate/20181117073558_create_recipes.rb
@@ -2,7 +2,8 @@ class CreateRecipes < ActiveRecord::Migration[5.2]
   def change
     create_table :recipes do |t|
       t.string :name
-      t.text :instructions
+      # added the array designation to instuctions...ok to alter existing migration file?
+      t.text :instructions, array: true, default: []
       t.string :photo_link
       t.integer :prep_time
       t.integer :cook_time


### PR DESCRIPTION
IMPORTANT!!  New migration / Migration alterations! We will be adding only recipes with numbered steps - these steps will have to be saved as an array in the instructions column. As such the migration for creating the recipe table has to be altered and prepare to accept arrays in the instructions column. this migration does this