### PR TITLE
Models match schema

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,5 +1,5 @@
 class Recipe < ApplicationRecord
-  has_many :recipe_components
+  has_many :recipe_ingredients
   has_many :user_recipes
   has_many :recipe_ratings
 

--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -1,4 +1,4 @@
-class RecipeComponent < ApplicationRecord
+class RecipeIngredient < ApplicationRecord
   belongs_to :ingredients
   belongs_to :imperial_measures
   belongs_to :metric_measures

--- a/app/models/spicy_level.rb
+++ b/app/models/spicy_level.rb
@@ -1,2 +1,0 @@
-class SpicyLevel < ApplicationRecord
-end

--- a/app/models/sub_category.rb
+++ b/app/models/sub_category.rb
@@ -1,2 +1,0 @@
-class SubCategory < ApplicationRecord
-end

--- a/db/migrate/20181120102335_drop_recipe_components.rb
+++ b/db/migrate/20181120102335_drop_recipe_components.rb
@@ -1,0 +1,5 @@
+class DropRecipeComponents < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :recipe_components
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_19_170609) do
+ActiveRecord::Schema.define(version: 2018_11_20_102335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,21 +76,6 @@ ActiveRecord::Schema.define(version: 2018_11_19_170609) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "recipe_components", force: :cascade do |t|
-    t.string "metric_quantity"
-    t.string "imperial_quantity"
-    t.bigint "ingredients_id"
-    t.bigint "imperial_measures_id"
-    t.bigint "metric_measures_id"
-    t.bigint "recipes_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["imperial_measures_id"], name: "index_recipe_components_on_imperial_measures_id"
-    t.index ["ingredients_id"], name: "index_recipe_components_on_ingredients_id"
-    t.index ["metric_measures_id"], name: "index_recipe_components_on_metric_measures_id"
-    t.index ["recipes_id"], name: "index_recipe_components_on_recipes_id"
   end
 
   create_table "recipe_ingredients", force: :cascade do |t|
@@ -198,10 +183,6 @@ ActiveRecord::Schema.define(version: 2018_11_19_170609) do
   add_foreign_key "category_recipes", "recipes"
   add_foreign_key "food_preference_users", "food_preferences"
   add_foreign_key "food_preference_users", "users"
-  add_foreign_key "recipe_components", "imperial_measures", column: "imperial_measures_id"
-  add_foreign_key "recipe_components", "ingredients", column: "ingredients_id"
-  add_foreign_key "recipe_components", "metric_measures", column: "metric_measures_id"
-  add_foreign_key "recipe_components", "recipes", column: "recipes_id"
   add_foreign_key "recipe_ingredients", "imperial_measures", column: "imperial_measures_id"
   add_foreign_key "recipe_ingredients", "ingredients", column: "ingredients_id"
   add_foreign_key "recipe_ingredients", "metric_measures", column: "metric_measures_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_17_084623) do
+ActiveRecord::Schema.define(version: 2018_11_19_170609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,21 @@ ActiveRecord::Schema.define(version: 2018_11_17_084623) do
     t.index ["recipes_id"], name: "index_recipe_components_on_recipes_id"
   end
 
+  create_table "recipe_ingredients", force: :cascade do |t|
+    t.string "metric_quantity"
+    t.string "imperial_quantity"
+    t.bigint "ingredients_id"
+    t.bigint "imperial_measures_id"
+    t.bigint "metric_measures_id"
+    t.bigint "recipes_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["imperial_measures_id"], name: "index_recipe_ingredients_on_imperial_measures_id"
+    t.index ["ingredients_id"], name: "index_recipe_ingredients_on_ingredients_id"
+    t.index ["metric_measures_id"], name: "index_recipe_ingredients_on_metric_measures_id"
+    t.index ["recipes_id"], name: "index_recipe_ingredients_on_recipes_id"
+  end
+
   create_table "recipe_ratings", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -116,6 +131,7 @@ ActiveRecord::Schema.define(version: 2018_11_17_084623) do
     t.integer "servings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "source"
   end
 
   create_table "special_diet_users", force: :cascade do |t|
@@ -186,6 +202,10 @@ ActiveRecord::Schema.define(version: 2018_11_17_084623) do
   add_foreign_key "recipe_components", "ingredients", column: "ingredients_id"
   add_foreign_key "recipe_components", "metric_measures", column: "metric_measures_id"
   add_foreign_key "recipe_components", "recipes", column: "recipes_id"
+  add_foreign_key "recipe_ingredients", "imperial_measures", column: "imperial_measures_id"
+  add_foreign_key "recipe_ingredients", "ingredients", column: "ingredients_id"
+  add_foreign_key "recipe_ingredients", "metric_measures", column: "metric_measures_id"
+  add_foreign_key "recipe_ingredients", "recipes", column: "recipes_id"
   add_foreign_key "recipe_ratings", "recipes", column: "recipes_id"
   add_foreign_key "recipe_ratings", "users", column: "users_id"
   add_foreign_key "special_diet_users", "special_diets"

--- a/test/models/spicy_level_test.rb
+++ b/test/models/spicy_level_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class SpicyLevelTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/sub_category_test.rb
+++ b/test/models/sub_category_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class SubCategoryTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
destroyed models spicy_level and sub_category
dropped recipe_components table
changed model name of recipe_component to recipe_ingredient and updated the parent table necessary (just recipe model)